### PR TITLE
[feature] Add linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ bower_components
 node_modules
 .env
 logs
+*.log
 dist

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,28 +1,15 @@
-var gulp = require('gulp');
-var webpack = require('webpack-stream');
+const gulp = require('gulp');
+const eslint = require('gulp-eslint');
 
-// Boilerplate Webpack stuff
+gulp.task('checkin', () => console.log('From what I can tell I\'m working fine'))
 
-gulp.task('default', function() {
-  return gulp.src('src/entry.js')
-    .pipe(webpack())
-    .pipe(gulp.dest('dist/'));
+gulp.task('lint', () => {
+    return gulp.src('src/**/*.js')
+      .pipe(eslint())
+      .pipe(eslint.format())
+      .pipe(eslint.failAfterError())
 });
 
-gulp.task("webpack-dev-server", function(callback) {
-    // Start a webpack-dev-server
-    var compiler = webpack({
-        // configuration
-    });
-
-    new WebpackDevServer(compiler, {
-        // server and middleware options
-    }).listen(8080, "localhost", function(err) {
-        if(err) throw new gutil.PluginError("webpack-dev-server", err);
-        // Server listening
-        gutil.log("[webpack-dev-server]", "http://localhost:8080/webpack-dev-server/index.html");
-
-        // keep the server alive or continue?
-        // callback();
-    });
+gulp.task('default', ['lint'], function() {
+  console.log('You old so and so.')
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,28 @@
+var gulp = require('gulp');
+var webpack = require('webpack-stream');
+
+// Boilerplate Webpack stuff
+
+gulp.task('default', function() {
+  return gulp.src('src/entry.js')
+    .pipe(webpack())
+    .pipe(gulp.dest('dist/'));
+});
+
+gulp.task("webpack-dev-server", function(callback) {
+    // Start a webpack-dev-server
+    var compiler = webpack({
+        // configuration
+    });
+
+    new WebpackDevServer(compiler, {
+        // server and middleware options
+    }).listen(8080, "localhost", function(err) {
+        if(err) throw new gutil.PluginError("webpack-dev-server", err);
+        // Server listening
+        gutil.log("[webpack-dev-server]", "http://localhost:8080/webpack-dev-server/index.html");
+
+        // keep the server alive or continue?
+        // callback();
+    });
+});

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "homepage": "https://github.com/HousePhillips2/Phyll#readme",
   "dependencies": {
     "body-parser": "^1.15.2",
-    "chai": "^3.5.0",
     "dotenv": "^2.0.0",
     "express": "^4.14.0",
     "express-partials": "^0.3.0",
@@ -33,14 +32,34 @@
     "babel": "^6.5.2",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "chai": "^3.5.0",
+    "eslint": "^3.5.0",
     "favicons-webpack-plugin": "0.0.7",
     "gulp": "^3.9.1",
+    "gulp-eslint": "^3.0.1",
     "gulp-inject": "^4.1.0",
+    "gulp-less": "^3.1.0",
+    "gulp-mocha": "^3.0.1",
+    "gulp-util": "^3.0.7",
     "gulp-webpack": "^1.5.0",
     "gulp-wiredep": "0.0.0",
     "html-webpack-plugin": "^2.22.0",
+    "jstest": "^1.0.5",
+    "mocha": "^3.0.2",
     "webpack": "^1.13.2",
     "webpack-dev-server": "^1.15.2",
     "webpack-stream": "^3.2.0"
+  },
+  "eslintConfig": {
+    "parserOptions": {
+      "ecmaVersion": 6,
+      "sourceType": "module",
+      "ecmaFeatures": {
+        "jsx": true
+      }
+    },
+    "rules": {
+      "semi": 2
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/server/server.js",
   "scripts": {
-    "start": "nodemon src/server/server.js"
+    "start": "nodemon src/server/server.js",
+    "build": "webpack"
   },
   "repository": {
     "type": "git",
@@ -32,11 +33,14 @@
     "babel": "^6.5.2",
     "babel-core": "^6.14.0",
     "babel-loader": "^6.2.5",
+    "favicons-webpack-plugin": "0.0.7",
     "gulp": "^3.9.1",
     "gulp-inject": "^4.1.0",
     "gulp-webpack": "^1.5.0",
     "gulp-wiredep": "0.0.0",
+    "html-webpack-plugin": "^2.22.0",
     "webpack": "^1.13.2",
+    "webpack-dev-server": "^1.15.2",
     "webpack-stream": "^3.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "express-session": "^1.14.1",
     "http": "0.0.0",
     "mocha": "^3.0.2",
-    "redux": "^3.6.0",
-    "semantic-ui": "^2.2.4"
+    "redux": "^3.6.0"
   },
   "devDependencies": {
     "babel": "^6.5.2",

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -15,4 +15,4 @@ console.log('Up and running on ' + port);
 
 app.use(express.static('src/public'));
 
-app.get('/', (req, res) => res.redirect('/index.html'))
+app.get('/', (req, res) => res.redirect('/index.html'));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,6 @@
+const path = require('path');
+const html = require('html-webpack-plugin');
+
+const paths = {
+  app: path.join(__dirname + 'src/public')
+}


### PR DESCRIPTION
Run linter with `gulp lint` command in root directory and errors will log to the terminal. This task will be part of the deployment build, but it works individually, too. Also pulled an unnecessary dependency that was initiating a redundant install of Semantic UI.
